### PR TITLE
Add other allowed symbols: "_", "-", and "+"

### DIFF
--- a/script/inject-sequences.js
+++ b/script/inject-sequences.js
@@ -15,7 +15,7 @@ for (const sequence of sequences) {
 	emojiSequenceSymbols.add([...sequence]);
 }
 
-const otherAllowedSymbols = ['_', '-', '+']
+const otherAllowedSymbols = ['_', '-', '+'];
 
 const Start = regenerate('#', '\uFF03');
 const Continue = regenerate('_')

--- a/script/inject-sequences.js
+++ b/script/inject-sequences.js
@@ -15,11 +15,14 @@ for (const sequence of sequences) {
 	emojiSequenceSymbols.add([...sequence]);
 }
 
+const otherAllowedSymbols = ['_', '-', '+']
+
 const Start = regenerate('#', '\uFF03');
 const Continue = regenerate('_')
 	.add(XID_Continue)
 	.add(Emoji)
 	.add(emojiSequenceSymbols)
+	.add(otherAllowedSymbols)
 	.remove(Start);
 
 const file = 'index.js';

--- a/test/tests.js
+++ b/test/tests.js
@@ -19,6 +19,8 @@ describe('Hashtag identifier regex', () => {
 
 	test('abc');
 	test('a_b_c');
+	test('a-b-c');
+	test('a+b+c');
 	test('\u{2F9DC}'); // XID_Continue
 
 	const Emoji = require('unicode-tr51/Emoji.js');


### PR DESCRIPTION
Hey @mathiasbynens! I think this repo might be missing a few symbols from the Unicode hashtag spec. When you have some time could you double-check this?

From: http://unicode.org/reports/tr31/#hashtag_identifiers

> Continue := XID_Continue, plus Emoji, Emoji_Component, and "_", "-", "+",
> minus Start characters.

Thanks to @qubist for pointing out this omission.

---

Backlink: https://github.com/qubist/ssb-markdown/pull/1